### PR TITLE
README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # LINUX_boot-able-Systems
 onepointfourhounderttousendmbssdbootablesys
+
+Portable hard disk
+                    ->bootable 
+                              -> running two LINUX Version's for various Computersystems. // for example machinaseven1982 ->but here the "hard disk" is onboard
+                              
+


### PR DESCRIPTION
The Project one,

a portable disk with most common LINUX add ons-
  - two running systems
  the main running one to be choosen during boot up
while BIOS first BOOT priority is selected-
 boot from usb ssd/drive divece ->if available in BIOS settings older szstems might use network bootup wgile device onepointfourhounderthousandmbssdbootablesys is connected to "someserver" in same network.


save readme badtype